### PR TITLE
Squitch requires DBD::SQLite

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -27,4 +27,5 @@ requires 'Task::Catalyst::Tutorial';
 requires 'Test2::V0';
 requires 'WWW::Mechanize';
 requires 'YAML';
+requires 'DBD::SQLite';
 test_requires 'Test::More' => '0.88';


### PR DESCRIPTION
Hello,

Following the [Development Instructions](https://github.com/kyzn/PRC/wiki/Development-Instructions) I get this error when running `sqitch deploy db:sqlite:prc.db` :

```
DBD::SQLite 1.37 required to manage SQLite
```
Adding this line to the cpanfile fixed the issue.
