### PR TITLE
Improve help page text

### DIFF
--- a/root/static/html/help.html
+++ b/root/static/html/help.html
@@ -7,18 +7,35 @@
 
 
   <h4>What is a pull request?</h4>
-  <p>Pull request is a way to contribute to open source projects. It contains a file showing changed lines. GitHub adds a discussion to pull requests. This is to let contributors and maintainers communicate. We recommend <a href="https://help.github.com/articles/about-pull-requests/" rel="nofollow" target="_blank">this article on GitHub</a> for more details.</p>
+  <p>Pull request is a way to contribute to open source projects. It
+  contains a file showing changed lines. GitHub adds a discussion to pull
+  requests. This is to let contributors and maintainers communicate. We
+  recommend <a href="https://help.github.com/articles/about-pull-requests/"
+  rel="nofollow" target="_blank">this article on GitHub</a> for more
+  details.</p>
   <br>
 
 
   <h4>How do I submit a pull request?</h4>
-  <p><a href="https://github.com/CPAN-PRC/resources/wiki/My-first-Pull-Request" rel="nofollow" target="_blank">This article</a> will walk you through your first pull request. <a href="https://github.com/CPAN-PRC/resources/wiki/Pull-Request-Ideas" rel="nofollow" target="_blank">This article</a> will give you some concrete pull request ideas.</p>
+  <p><a href="https://github.com/CPAN-PRC/resources/wiki/My-first-Pull-Request"
+  rel="nofollow" target="_blank">This article</a> will walk you through
+  your first pull request.
+  <a href="https://github.com/CPAN-PRC/resources/wiki/Pull-Request-Ideas"
+  rel="nofollow" target="_blank">This article</a> will give you some
+  concrete pull request ideas.</p>
   <br>
 
 
   <h4>What is Pull Request Club?</h4>
-  <p>Pull Request Club is an online application. If you are looking for open source projects to submit a pull request, it can find you one. If you have a project and looking for people who would submit pull requests, it can find you some.</p>
-  <p>We built Pull Request Club to be a successor of <a href='http://cpan-prc.org/' rel="nofollow" target='_blank'>The CPAN Pull Request Challenge</a>. We are grateful to Neil Bowers, who run CPAN-PRC for 4 years (January 2015 to December 2018).</p>
+  <p>Pull Request Club is an online application. If you are looking for open
+  source projects to submit a pull request, it can find you one. If you have
+  a project and looking for people who would submit pull requests, it can
+  find you some.
+  </p>
+  <p>We built Pull Request Club to be a successor of
+  <a href='http://cpan-prc.org/' rel="nofollow" target='_blank'>The CPAN Pull
+  Request Challenge</a>. We are grateful to Neil Bowers, who run CPAN-PRC for
+  4 years (January 2015 to December 2018).</p>
   <br>
 
 
@@ -28,32 +45,42 @@
 
 
   <h4>What is an assignment?</h4>
-  <p>An assignment is a GitHub repository assigned to a user. Users who receive an assignment should submit at least one pull request.</p>
+  <p>An assignment is a GitHub repository assigned to a user. Users who
+  receive an assignment should submit at least one pull request.</p>
   <br>
 
 
   <h4>How can I receive assignments?</h4>
-  <p>After you sign up and agree to the Terms of Use, you need to make sure to check GET ASSIGNMENTS in <a href="/settings">settings</a>. If you have an open assignment you won't receive a new one.</p>
+  <p>After you sign up and agree to the Terms of Use, you need to make sure
+  to check GET ASSIGNMENTS in <a href="/settings">settings</a>. If you have
+  an open assignment you won't receive a new one.</p>
   <br>
 
 
   <h4>What is an open assignment?</h4>
-  <p>It's an unfinished assignment that is not marked as DONE or SKIPPED yet. If you have an open assignment you won't receive a new one.</p>
+  <p>It's an unfinished assignment that is not marked as DONE or SKIPPED
+  yet. If you have an open assignment you won't receive a new one.</p>
   <br>
 
 
   <h4>When do I get assignments?</h4>
-  <p>We send assignments at the top of each month. You can receive up to 12 assignments a year.</p>
+  <p>We send assignments at the top of each month. You can receive up to 12
+  assignments a year.</p>
   <br>
 
 
   <h4>Can I select programming languages for my assignments?</h4>
-  <p>You can select your preferred languages in <a href="/settings">settings</a>. Please note that we cannot guarantee to get you assignments in your preferred languages.</p>
+  <p>You can select your preferred languages in
+  <a href="/settings">settings</a>. Please note that we cannot guarantee to
+  get you assignments in your preferred languages.</p>
   <br>
 
 
   <h4>How do I complete an assignment?</h4>
-  <p>Submit at least one pull request to your assignment repository on GitHub. Then click DONE in <a href="/my-assignment">your assignment</a> page. You don't have to wait for maintainers to merge your pull request.</p>
+  <p>Submit at least one pull request to your assignment repository on
+  GitHub. Then click DONE in <a href="/my-assignment">your assignment</a>
+  page. You don't have to wait for maintainers to merge your pull
+  request.</p>
   <br>
 
 
@@ -63,12 +90,22 @@
 
 
   <h4>I don't like my assignment, can I get a different one?</h4>
-  <p>While that is not possible on site, we may be able to help. Contact us via <a href="mailto:kyzn@cpan.org" rel="nofollow" target="_blank">kyzn@cpan.org</a> or <a href="https://twitter.com/PullRequestClub" rel="nofollow" target="_blank">@PullRequestClub</a>. By contacting us you agree to our <a href='/legal'>privacy policy</a> and agree to receive a response from us for your question.</p>
+
+  <p>While that is not possible on site, we may be able to help. Contact us
+  via <a href="mailto:kyzn@cpan.org" rel="nofollow"
+  target="_blank">kyzn@cpan.org</a> or <a
+  href="https://twitter.com/PullRequestClub" rel="nofollow"
+  target="_blank">@PullRequestClub</a>. By contacting us you agree to our <a
+  href='/legal'>privacy policy</a> and agree to receive a response from us for
+  your question.</p>
   <br>
 
 
   <h4>I need more time for my assignment.</h4>
-  <p>That is OK! Your assignment will stay OPEN until you mark it as DONE or SKIPPED. Note that if you have an open assignment you won't receive a new one.</p>
+
+  <p>That is OK! Your assignment will stay OPEN until you mark it as DONE or
+  SKIPPED. Note that if you have an open assignment you won't receive a new
+  one.</p>
   <br>
 
 
@@ -78,18 +115,22 @@
 
 
   <h4>How can I receive assignees?</h4>
-  <p>After you sign up and agree to the Terms of Use, you need to make sure to select repositories in <a href="/settings">settings</a>.</p>
+  <p>After you sign up and agree to the Terms of Use, you need to make sure
+  to select repositories in <a href="/settings">settings</a>.</p>
   <br>
 
 
   <h4>Can I get assignees for my organization repos?</h4>
-  <p>Yes! Go to your <a href="/settings">settings</a> and you will see a separate section for organizational repositories. If your organization is already claimed by another user, it won't show up in your settings.</p>
+  <p>Yes! Go to your <a href="/settings">settings</a> and you will see a
+  separate section for organizational repositories. If your organization is
+  already claimed by another user, it won't show up in your settings.</p>
   <br>
 
 
 
   <h4>Can you guarantee my repos will get assignees?</h4>
-  <p>Unfortunately we can't. You can create issues in GitHub to increase the likelihood of getting assignees.</p>
+  <p>Unfortunately we can't. You can create issues in GitHub to increase the
+  likelihood of getting assignees.</p>
   <br>
 
 
@@ -109,32 +150,40 @@
 
 
   <h4>Can I deactivate my account?</h4>
-  <p>You can at <a href="/settings">settings</a> page. Note that a deactivated account will not receive further assignments or assignees.</p>
+  <p>You can at <a href="/settings">settings</a> page. Note that a
+  deactivated account will not receive further assignments or assignees.</p>
   <br>
 
 
   <h4>Can I delete my account?</h4>
-  <p>You can at <a href="/settings">settings</a> page. We will immediately deactivate your account and schedule a deletion for 30 days. Note that a deactivated account will not receive further assignments or assignees.</p>
+  <p>You can at <a href="/settings">settings</a> page. We will immediately
+  deactivate your account and schedule a deletion for 30 days. Note that a
+  deactivated account will not receive further assignments or assignees.</p>
   <br>
 
 
   <h4>I deactivated my account, can I reactivate it?</h4>
-  <p>Yes! When you login, we will take you to a reactivation page. You need to reactivate your account to continue using the site.</p>
+  <p>Yes! When you login, we will take you to a reactivation page. You need
+  to reactivate your account to continue using the site.</p>
   <br>
 
 
   <h4>I scheduled a deletion of my account, can I cancel it?</h4>
-  <p>You can, but only if it hasn't been 30 days yet. When you login, we will take you to a reactivation page. Once you reactivate your account we will clear your scheduled deletion.</p>
+  <p>You can, but only if it hasn't been 30 days yet. When you login, we
+  will take you to a reactivation page. Once you reactivate your account we
+  will clear your scheduled deletion.</p>
   <br>
 
 
   <h4>I deleted my account. Can I bring my data back?</h4>
-  <p>Unfortunately we can't bring back your deleted data. You can create an account from scratch by signing up.</p>
+  <p>Unfortunately we can't bring back your deleted data. You can create an
+  account from scratch by signing up.</p>
   <br>
 
 
   <h4>Some items in my history are missing. What happened?</h4>
-  <p>We are sorry that happened. Users can request a deletion of their data, which can cause some items in your history to disappear.</p>
+  <p>We are sorry that happened. Users can request a deletion of their data,
+  which can cause some items in your history to disappear.</p>
   <br>
 
 
@@ -149,12 +198,21 @@
 
 
   <h4>Can I get a notification when I receive an assignment/assignee?</h4>
-  <p>You can get an email when a new assignment is assigned to you. "New assignee" notification is still a work in progress. Go to your <a href="/settings">settings</a> and find email notifications. We also recommend you to follow <a href="https://twitter.com/PullRequestClub" rel="nofollow" target="_blank">our Twitter account</a>.</p>
+  <p>You can get an email when a new assignment is assigned to you. "New
+  assignee" notification is still a work in progress. Go to your
+  <a href="/settings">settings</a> and find email notifications. We also
+  recommend you to follow <a href="https://twitter.com/PullRequestClub"
+  rel="nofollow" target="_blank">our Twitter account</a>.</p>
   <br>
 
 
   <h4>I need more help.</h4>
-  <p>Feel free to get in touch with us at <a href="mailto:kyzn@cpan.org" rel="nofollow" target="_blank">kyzn@cpan.org</a> or <a href="https://twitter.com/PullRequestClub" rel="nofollow" target="_blank">@PullRequestClub</a>. By contacting us you agree to our <a href='/legal'>privacy policy</a> and agree to receive a response from us for your question.</p>
+  <p>Feel free to get in touch with us at <a href="mailto:kyzn@cpan.org"
+  rel="nofollow" target="_blank">kyzn@cpan.org</a> or
+  <a href="https://twitter.com/PullRequestClub" rel="nofollow"
+  target="_blank">@PullRequestClub</a>. By contacting us you agree to our <a
+  href='/legal'>privacy policy</a> and agree to receive a response from us
+  for your question.</p>
   <br>
 
 </div>

--- a/root/static/html/help.html
+++ b/root/static/html/help.html
@@ -7,10 +7,10 @@
 
 
   <h4>What is a pull request?</h4>
-  <p>Pull request is a way to contribute to open source projects. It
+  <p>A pull request is a way to contribute to open source projects. It
   contains a file showing changed lines. GitHub adds a discussion to pull
   requests. This is to let contributors and maintainers communicate. We
-  recommend <a href="https://help.github.com/articles/about-pull-requests/"
+  recommend reading <a href="https://help.github.com/articles/about-pull-requests/"
   rel="nofollow" target="_blank">this article on GitHub</a> for more
   details.</p>
   <br>
@@ -64,7 +64,7 @@
 
 
   <h4>When do I get assignments?</h4>
-  <p>We send assignments at the top of each month. You can receive up to 12
+  <p>We send assignments at the beginning of each month. You can receive up to 12
   assignments a year.</p>
   <br>
 
@@ -139,8 +139,8 @@
   <br>
 
 
-  <p>You can see your assignees in <a href="/history">history</a> page.
   <h4>How can I know who has received my repositories as their assignments?</h4>
+  <p>You can see your assignees on the <a href="/history">history</a> page.
   <br>
 
 
@@ -150,13 +150,13 @@
 
 
   <h4>Can I deactivate my account?</h4>
-  <p>You can at <a href="/settings">settings</a> page. Note that a
+  <p>You can deactivate your account via the <a href="/settings">settings</a> page. Note that a
   deactivated account will not receive further assignments or assignees.</p>
   <br>
 
 
   <h4>Can I delete my account?</h4>
-  <p>You can at <a href="/settings">settings</a> page. We will immediately
+  <p>You can delete your account via the <a href="/settings">settings</a> page. We will immediately
   deactivate your account and schedule a deletion in 30 days. Note that a
   deactivated account will not receive further assignments or assignees.</p>
   <br>
@@ -200,7 +200,7 @@
   <h4>Can I get a notification when I receive an assignment/assignee?</h4>
   <p>You can get an email when a new assignment is assigned to you. "New
   assignee" notification is still a work in progress. Go to your
-  <a href="/settings">settings</a> and find email notifications. We also
+  <a href="/settings">settings</a> and select the "Email" tab. We also
   recommend you to follow <a href="https://twitter.com/PullRequestClub"
   rel="nofollow" target="_blank">our Twitter account</a>.</p>
   <br>

--- a/root/static/html/help.html
+++ b/root/static/html/help.html
@@ -28,13 +28,13 @@
 
   <h4>What is Pull Request Club?</h4>
   <p>Pull Request Club is an online application. If you are looking for open
-  source projects to submit a pull request, it can find you one. If you have
-  a project and looking for people who would submit pull requests, it can
+  source projects to submit a pull request to, it can find you one. If you have
+  a project and are looking for people who would submit pull requests, it can
   find you some.
   </p>
   <p>We built Pull Request Club to be a successor of
   <a href='http://cpan-prc.org/' rel="nofollow" target='_blank'>The CPAN Pull
-  Request Challenge</a>. We are grateful to Neil Bowers, who run CPAN-PRC for
+  Request Challenge</a>. We are grateful to Neil Bowers, who ran the CPAN-PRC for
   4 years (January 2015 to December 2018).</p>
   <br>
 
@@ -139,8 +139,8 @@
   <br>
 
 
-  <h4>How can I know who have received my repositories as their assignments?</h4>
   <p>You can see your assignees in <a href="/history">history</a> page.
+  <h4>How can I know who has received my repositories as their assignments?</h4>
   <br>
 
 
@@ -157,7 +157,7 @@
 
   <h4>Can I delete my account?</h4>
   <p>You can at <a href="/settings">settings</a> page. We will immediately
-  deactivate your account and schedule a deletion for 30 days. Note that a
+  deactivate your account and schedule a deletion in 30 days. Note that a
   deactivated account will not receive further assignments or assignees.</p>
   <br>
 


### PR DESCRIPTION
While reading the Pull Request Club help page I noticed some minor grammatical errors and places where the sentence flow could be improved.  I've implemented these improvements here.  I've split the changes into separate commits so that you can see the changes more easily (I've also wrapped the code in the first commit so that the remaining diffs are easier to read).  The complete set of changes displayed by GitHub unfortunately obscures the textual changes made here, so it is likely better to consider each commit (and its diff) separately.

This PR is intended to be helpful. If you would like anything changed with this PR, please don't hesitate to let me know and I'll update it and resubmit as necessary. :-)